### PR TITLE
Enable CSV upload and side-by-side chatbot view

### DIFF
--- a/research_agent/requirements.txt
+++ b/research_agent/requirements.txt
@@ -5,3 +5,4 @@ pydantic_settings==2.11.0
 python-dotenv==1.1.1
 streamlit==1.46.1
 openai==1.56.0
+pandas==2.2.3


### PR DESCRIPTION
Add a new 'CSV + Chatbot' page to the Streamlit app, enabling users to upload CSVs and interact with a chatbot about their content.

This PR introduces a new section in the application where users can upload a CSV file, view a configurable preview of its data, and engage in a side-by-side chat with an Azure OpenAI-powered chatbot. The chatbot uses the CSV preview as context to answer questions, fulfilling the requirement for interactive CSV analysis.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0f53953-bd8d-4009-9b43-061e71e2eda6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0f53953-bd8d-4009-9b43-061e71e2eda6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

